### PR TITLE
Enable VA-API hardware decoding

### DIFF
--- a/dev.geopjr.Tuba.yaml
+++ b/dev.geopjr.Tuba.yaml
@@ -10,6 +10,7 @@ finish-args:
   - --socket=fallback-x11
   - --socket=wayland
   - --socket=pulseaudio
+  - --env=GST_PLUGIN_FEATURE_RANK=vaav1dec:MAX,vavp9dec:MAX,vavp8dec:MAX,vah264dec:MAX
 cleanup:
   - /include
   - /lib/pkgconfig


### PR DESCRIPTION
This enables VA-API hw decoding on Gstreamer versions prior to 1.24, where most `va*` plugins finally got promoted to primary. It mirrors what various Gst based video players have been doing for a while, as the plugins are already very stable in 1.22 - the version shipped in the FDO 23.08 runtime, which in turn is the base for the Gnome 46 runtime.

This can improve video playback performance quite significantly on Intel and AMD setups during the 46 cycle. It can be tested with: `flatpak override --user --env=GST_PLUGIN_FEATURE_RANK=vaav1dec:MAX,vavp9dec:MAX,vavp8dec:MAX,vah264dec:MAX dev.geopjr.Tuba`