### PR TITLE
feat(metainfo): lock git lfs screenshots

### DIFF
--- a/dev.geopjr.Tuba.yaml
+++ b/dev.geopjr.Tuba.yaml
@@ -126,3 +126,5 @@ modules:
         x-checker-data:
           type: git
           tag-pattern: ^v([\d.]+)$
+      - type: patch
+        path: feat-metainfo-lock-screenshots.patch # https://github.com/GeopJr/Tuba/pull/1578

--- a/feat-metainfo-lock-screenshots.patch
+++ b/feat-metainfo-lock-screenshots.patch
@@ -1,0 +1,52 @@
+From 9fb20a5343ff0fb2bde23757234de632d2994397 Mon Sep 17 00:00:00 2001
+From: Evan Paterakis <evan@geopjr.dev>
+Date: Thu, 16 Oct 2025 02:17:11 +0300
+Subject: [PATCH] feat(metainfo): lock git lfs screenshots
+
+---
+ data/dev.geopjr.Tuba.metainfo.xml.in | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/data/dev.geopjr.Tuba.metainfo.xml.in b/data/dev.geopjr.Tuba.metainfo.xml.in
+index ad03d4d8..6bc399e3 100644
+--- a/data/dev.geopjr.Tuba.metainfo.xml.in
++++ b/data/dev.geopjr.Tuba.metainfo.xml.in
+@@ -32,31 +32,31 @@
+   <url type="contribute">https://github.com/GeopJr/Tuba#contributing</url>
+   <screenshots>
+     <screenshot type="default">
+-      <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/main/data/screenshots/screenshot-1.png</image>
++      <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/7f919343ea87ab04455d9087f16ca38a0680dc08/data/screenshots/screenshot-1.png</image>
+       <caption>Home Timeline</caption>
+     </screenshot>
+     <screenshot>
+-      <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/main/data/screenshots/screenshot-2.png</image>
++      <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/7f919343ea87ab04455d9087f16ca38a0680dc08/data/screenshots/screenshot-2.png</image>
+       <caption>Composer</caption>
+     </screenshot>
+     <screenshot>
+-      <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/main/data/screenshots/screenshot-3.png</image>
++      <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/7f919343ea87ab04455d9087f16ca38a0680dc08/data/screenshots/screenshot-3.png</image>
+       <caption>Profile View</caption>
+     </screenshot>
+     <screenshot>
+-      <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/main/data/screenshots/screenshot-4.png</image>
++      <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/7f919343ea87ab04455d9087f16ca38a0680dc08/data/screenshots/screenshot-4.png</image>
+       <caption>Home Timeline</caption>
+     </screenshot>
+     <screenshot>
+-      <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/main/data/screenshots/screenshot-5.png</image>
++      <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/7f919343ea87ab04455d9087f16ca38a0680dc08/data/screenshots/screenshot-5.png</image>
+       <caption>Schedule Post Dialog</caption>
+     </screenshot>
+     <screenshot>
+-      <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/main/data/screenshots/screenshot-6.png</image>
++      <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/7f919343ea87ab04455d9087f16ca38a0680dc08/data/screenshots/screenshot-6.png</image>
+       <caption>Scheduled Posts</caption>
+     </screenshot>
+     <screenshot>
+-      <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/main/data/screenshots/screenshot-7.png</image>
++      <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/7f919343ea87ab04455d9087f16ca38a0680dc08/data/screenshots/screenshot-7.png</image>
+       <caption>Search View</caption>
+     </screenshot>
+   </screenshots>


### PR DESCRIPTION
screenshots would point to the main branch lfs state, they are now locked.

Patch from https://github.com/GeopJr/Tuba/pull/1578